### PR TITLE
audio-echo: fix lint warnings

### DIFF
--- a/audio-echo/app/src/main/AndroidManifest.xml
+++ b/audio-echo/app/src/main/AndroidManifest.xml
@@ -2,8 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.sample.echo" >
 
+    <uses-permission android:name="android.permission.RECORD_AUDIO"></uses-permission>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"></uses-permission>
+    <uses-permission android:name="android.permission.INTERNET"></uses-permission>
+    <!-- debug-writing file need external storage writing -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>  
+  
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+	android:supportsRtl="true"	
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
@@ -18,10 +25,4 @@
             </intent-filter>
         </activity>
     </application>
-
-    <uses-permission android:name="android.permission.RECORD_AUDIO"></uses-permission>
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"></uses-permission>
-    <uses-permission android:name="android.permission.INTERNET"></uses-permission>
-    <!-- debug-writing file need external storage writing -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 </manifest>

--- a/audio-echo/app/src/main/res/layout/activity_main.xml
+++ b/audio-echo/app/src/main/res/layout/activity_main.xml
@@ -17,12 +17,13 @@
         android:layout_height="wrap_content"
         android:text="@string/StopEcho"
         android:onClick="stopEcho"
+        android:layout_toEndOf="@+id/button_start_capture"
         android:layout_alignBottom="@+id/button_start_capture"
         android:layout_alignParentEnd="true" />
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Get Param"
+        android:text="@string/GetParam"
         android:id="@+id/get_parameter_button"
         android:layout_above="@+id/statusView"
         android:layout_alignParentStart="true"

--- a/audio-echo/app/src/main/res/values/strings.xml
+++ b/audio-echo/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="action_settings">Settings</string>
     <string name="StartEcho">Start</string>
     <string name="StopEcho">Stop</string>
+    <string name="GetParam">Get Param</string>    
 </resources>


### PR DESCRIPTION
fix the following lint warnings
```
Security
1	Warning AllowBackup: Missing allowBackup attribute
Internationalization
1	Warning RelativeOverlap: Overlapping items in RelativeLayout
Bi-directional Text
1	Warning RtlHardcoded: Using left/right instead of start/end attributes
```

Related #82