### PR TITLE
hello-thirdparty: add manual step to run fetch-gpg-sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ script:
     (! grep -n $'\t' */app/src/main/AndroidManifest.xml) | cat -t; test ${PIPESTATUS[0]} -eq 0
   # check that there is no trailing spaces in AndroidManifest    
   - |-
-    (! grep -E '\s+$' */app/src/main/AndroidManifest.xml) | cat -e; test ${PIPESTATUS[0]} -eq 0  
+    (! grep -E '\s+$' */app/src/main/AndroidManifest.xml) | cat -e; test ${PIPESTATUS[0]} -eq 0
+  - (cd hello-thirdparty && ./gradlew download_and_stage_gpg_sdk)
   - (cd builder && ./gradlew test)
   # print build failure summary
   - pandoc builder/build/reports/tests/index.html -t plain | sed -n '/^Failed tests/,/default-package/p'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,6 @@ environment:
 install:
   - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter android-23,platform-tools,tools,build-tools-23.0.0,extra-google-m2repository,extra-android-m2repository
 build_script:
-  - cd c:\projects\android-ndk\hello-thirdparty && gradlew download_and_stage_gpg_sdk)
+  - cd c:\projects\android-ndk\hello-thirdparty && gradlew download_and_stage_gpg_sdk
   - cd c:\projects\android-ndk\builder && gradlew test
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,6 @@ environment:
 install:
   - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter android-23,platform-tools,tools,build-tools-23.0.0,extra-google-m2repository,extra-android-m2repository
 build_script:
-  - cd c:\projects\android-ndk\hello-thirdparty && ./gradlew download_and_stage_gpg_sdk)
+  - cd c:\projects\android-ndk\hello-thirdparty && gradlew download_and_stage_gpg_sdk)
   - cd c:\projects\android-ndk\builder && gradlew test
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,6 @@ environment:
 install:
   - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter android-23,platform-tools,tools,build-tools-23.0.0,extra-google-m2repository,extra-android-m2repository
 build_script:
-  - cd builder
-  - gradlew test
+  - cd c:\projects\android-ndk\hello-thirdparty && ./gradlew download_and_stage_gpg_sdk)
+  - cd c:\projects\android-ndk\builder && gradlew test
 test: off

--- a/hello-thirdparty/README.md
+++ b/hello-thirdparty/README.md
@@ -14,6 +14,8 @@ Getting Started
 1. Open *File/Project Structure...*
   - Click *Download* or *Select NDK location*.
 1. Click *Tools/Android/Sync Project with Gradle Files*.
+1. Right Click on build.gradle for module `gpg-sdk`
+  - Select 'Run build'
 1. Update the source with the details of your project:
   - Update the package name in `app/build.gradle` and  `app/src/main/AndroidManifest.xml`.
   - Set `APP_ID` in `app/res/values/ids.xml` to the ID your project in the *Game services* section of the Google Play console.

--- a/hello-thirdparty/app/build.gradle
+++ b/hello-thirdparty/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.model.application'
 
 
- def gpg_sdk_path = file(project(':thirdparty:gpg-sdk').projectDir).absolutePath + "/gpg-cpp-sdk/android"
+def gpg_sdk_path = file(project(':thirdparty:gpg-sdk').projectDir).absolutePath + "/gpg-cpp-sdk/android"
 
 model {
     android {
@@ -44,12 +44,10 @@ model {
     }
 }
 
-
 dependencies {
     compile 'com.google.android.gms:play-services-games:7.8.0'
     compile 'com.google.android.gms:play-services-base:7.8.0'
     compile 'com.google.android.gms:play-services-appstate:7.8.0'
     compile 'com.google.android.gms:play-services-nearby:7.8.0'
-    compile project(':thirdparty:gpg-sdk')
 }
 

--- a/hello-thirdparty/thirdparty/gpg-sdk/build.gradle
+++ b/hello-thirdparty/thirdparty/gpg-sdk/build.gradle
@@ -1,7 +1,6 @@
 /*
     sub module to download the Google Play games
  */
-apply plugin: 'java'
 project.ext {
     gpg_sdk_link = 'https://developers.google.com/games/services/downloads/gpg-cpp-sdk.v1.4.1.zip'
 }
@@ -47,8 +46,5 @@ task clean_sdk () {
         delete 'build'
     }
 }
-tasks['clean'].dependsOn('clean_sdk')
 
 defaultTasks = ['download_and_stage_gpg_sdk']
-
-tasks['jar'].dependsOn('download_and_stage_gpg_sdk')


### PR DESCRIPTION
Fixes #89

/cc @claywilkinson @rschiu @gcasey

I'm not very familiar with how to set non-library-dependencies between module tasks, let me know if there is a better way.
