### PR TITLE
Fixed error where the plasma does not animate on some devices.

### DIFF
--- a/native-plasma/app/src/main/jni/plasma.c
+++ b/native-plasma/app/src/main/jni/plasma.c
@@ -379,7 +379,6 @@ struct engine {
     int animating;
 };
 
-static struct timespec now;
 static int64_t start_ms;
 static void engine_draw_frame(struct engine* engine) {
     if (engine->app->window == NULL) {
@@ -395,6 +394,7 @@ static void engine_draw_frame(struct engine* engine) {
 
     stats_startFrame(&engine->stats);
 
+    struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     int64_t time_ms = (((int64_t)now.tv_sec)*1000000000LL + now.tv_nsec)/1000000;
     time_ms -= start_ms;
@@ -463,6 +463,7 @@ void android_main(struct android_app* state) {
         init = 1;
     }
 
+    struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     start_ms = (((int64_t)now.tv_sec)*1000000000LL + now.tv_nsec)/1000000;
 

--- a/native-plasma/app/src/main/jni/plasma.c
+++ b/native-plasma/app/src/main/jni/plasma.c
@@ -379,6 +379,8 @@ struct engine {
     int animating;
 };
 
+static struct timespec now;
+static int64_t start_ms;
 static void engine_draw_frame(struct engine* engine) {
     if (engine->app->window == NULL) {
         // No window.
@@ -393,10 +395,9 @@ static void engine_draw_frame(struct engine* engine) {
 
     stats_startFrame(&engine->stats);
 
-    struct timespec t;
-    t.tv_sec = t.tv_nsec = 0;
-    clock_gettime(CLOCK_MONOTONIC, &t);
-    int64_t time_ms = (((int64_t)t.tv_sec)*1000000000LL + t.tv_nsec)/1000000;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    int64_t time_ms = (((int64_t)now.tv_sec)*1000000000LL + now.tv_nsec)/1000000;
+    time_ms -= start_ms;
 
     /* Now fill the values with a nice little plasma */
     fill_plasma(&buffer, time_ms);
@@ -461,6 +462,9 @@ void android_main(struct android_app* state) {
         init_tables();
         init = 1;
     }
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    start_ms = (((int64_t)now.tv_sec)*1000000000LL + now.tv_nsec)/1000000;
 
     stats_init(&engine.stats);
 


### PR DESCRIPTION
This ndk example has never worked on my Nexus 7 2013, although it works on my Galaxy S3 for some reason. I finally decided to try and fix it.
If on the Galaxy S3 I increment the time_ms variable to be near the value which the Nexus 7 assigns time_ms, the plasma will not animate. Likewise if on the Nexus 7 I decrement the time_ms variable to be near the value which the Galaxy S3 assigns time_ms, the plasma will animate.
So instead of using just any time spit out by clock_gettime(), I decided to use the time since start of program.
This is my first contribution to any code online ever ;) Hope it helps!