### PR TITLE
port hello-thirdparty to use new 0.6.0 native dependencies system

### DIFF
--- a/hello-thirdparty/app/build.gradle
+++ b/hello-thirdparty/app/build.gradle
@@ -33,7 +33,7 @@ model {
         moduleName = "native-activity"
         platformVersion = 9 //same as minSdkVersion.apiLevel for better compatibility
         stl    = "c++_static"
-        ldLibs.addAll(["atomic", "log", "android", "EGL", "GLESv1_CM", "z"])
+        ldLibs.addAll(["atomic", "log", "android", "EGL", "GLESv1_CM", "z"]) //gpg depends on atomic, log and z
         abiFilters.addAll(["armeabi", "armeabi-v7a", "x86", "arm64-v8a"]) //filtering ABIs on the ones Google Play Games library is compatible with.
     }
 

--- a/hello-thirdparty/app/build.gradle
+++ b/hello-thirdparty/app/build.gradle
@@ -8,7 +8,11 @@ model {
         libs(PrebuiltLibraries) {
             gpg {
                 headers.srcDir "${gpg_sdk_path}/include"
-                binaries.withType(SharedLibraryBinary) { // NOTE: this block should be "StaticLibraryBinary"/staticLibraryFile - but SharedLibraryBinary works and StaticLibraryBinary doesn't as of 0.6.0-alpha1
+                binaries.withType(SharedLibraryBinary) {
+                    //
+                    // NOTE: this block should be "StaticLibraryBinary"/staticLibraryFile - but SharedLibraryBinary works and StaticLibraryBinary doesn't as of 0.6.0-alpha2
+                    // bug reported here: https://code.google.com/p/android/issues/detail?id=196065
+                    //
                     sharedLibraryFile = file("${gpg_sdk_path}/lib/c++/${targetPlatform.getName()}/libgpg.a")
                 }
             }

--- a/hello-thirdparty/app/build.gradle
+++ b/hello-thirdparty/app/build.gradle
@@ -1,12 +1,23 @@
 apply plugin: 'com.android.model.application'
 
-
 def gpg_sdk_path = file(project(':thirdparty:gpg-sdk').projectDir).absolutePath + "/gpg-cpp-sdk/android"
 
 model {
+
+    repositories {
+        libs(PrebuiltLibraries) {
+            gpg {
+                headers.srcDir "${gpg_sdk_path}/include"
+                binaries.withType(SharedLibraryBinary) { // NOTE: this block should be "StaticLibraryBinary"/staticLibraryFile - but SharedLibraryBinary works and StaticLibraryBinary doesn't as of 0.6.0-alpha1
+                    sharedLibraryFile = file("${gpg_sdk_path}/lib/c++/${targetPlatform.getName()}/libgpg.a")
+                }
+            }
+        }
+    }
+
     android {
         compileSdkVersion = 23
-        buildToolsVersion = "23.0.0"
+        buildToolsVersion = "23.0.2"
 
         defaultConfig.with {
             //
@@ -18,42 +29,34 @@ model {
         }
     }
 
-    compileOptions.with {
-        sourceCompatibility=JavaVersion.VERSION_1_7
-        targetCompatibility=JavaVersion.VERSION_1_7
-    }
-
     android.ndk {
         moduleName = "native-activity"
-        cppFlags.addAll(["-I${file("src/main/jni")}".toString(),
-	                 "-I${gpg_sdk_path}/include".toString()])
+        platformVersion = 9 //same as minSdkVersion.apiLevel for better compatibility
         stl    = "c++_static"
-        ldLibs.addAll(["log", "android", "EGL", "GLESv1_CM", "z"])
-        //
-        //  NOTE: since libgpg is also linked to the stl:
-        //  libc++ explicitly follows it in the list of libraries
-        //  to prevent unresolved stl symbols.
-        //
-        ldLibs.addAll(["gpg", "c++_static"])
+        ldLibs.addAll(["atomic", "log", "android", "EGL", "GLESv1_CM", "z"])
+        abiFilters.addAll(["armeabi", "armeabi-v7a", "x86", "arm64-v8a"]) //filtering ABIs on the ones Google Play Games library is compatible with.
     }
+
+    android.sources {
+        main {
+            jni {
+                dependencies {
+                    library "gpg"
+                }
+            }
+        }
+    }
+
     android.buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles.add(file('proguard-rules.txt'))
-        }
-    }
-    android.productFlavors {
-        create ("arm7") {
-            ndk.abiFilters.add("armeabi-v7a")
-            ndk.ldFlags.add("-L${gpg_sdk_path}/lib/c++/armeabi-v7a".toString())
         }
     }
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-games:7.8.0'
-    compile 'com.google.android.gms:play-services-base:7.8.0'
-    compile 'com.google.android.gms:play-services-appstate:7.8.0'
-    compile 'com.google.android.gms:play-services-nearby:7.8.0'
+    compile 'com.google.android.gms:play-services-games:8.3.0'
+    compile 'com.google.android.gms:play-services-base:8.3.0'
+    compile 'com.google.android.gms:play-services-appstate:8.3.0'
+    compile 'com.google.android.gms:play-services-nearby:8.3.0'
 }
-

--- a/hello-thirdparty/app/build.gradle
+++ b/hello-thirdparty/app/build.gradle
@@ -17,7 +17,7 @@ model {
 
     android {
         compileSdkVersion = 23
-        buildToolsVersion = "23.0.2"
+        buildToolsVersion = "23.0.0"
 
         defaultConfig.with {
             //

--- a/hello-thirdparty/app/src/main/AndroidManifest.xml
+++ b/hello-thirdparty/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
   <application
       android:allowBackup="false"
       android:fullBackupContent="false"
-      android:hasCode="false"
+      android:hasCode="true"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name">
     <meta-data android:name="com.google.android.gms.games.APP_ID"

--- a/hello-thirdparty/build.gradle
+++ b/hello-thirdparty/build.gradle
@@ -4,7 +4,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.4.0'
+        classpath 'com.android.tools.build:gradle-experimental:0.6.0-alpha1'
     }
 }
 

--- a/hello-thirdparty/build.gradle
+++ b/hello-thirdparty/build.gradle
@@ -4,7 +4,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.6.0-alpha1'
+        classpath 'com.android.tools.build:gradle-experimental:0.6.0-alpha2'
     }
 }
 

--- a/hello-thirdparty/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-thirdparty/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip

--- a/hello-thirdparty/thirdparty/gpg-sdk/build.gradle
+++ b/hello-thirdparty/thirdparty/gpg-sdk/build.gradle
@@ -2,7 +2,7 @@
     sub module to download the Google Play games
  */
 project.ext {
-    gpg_sdk_link = 'https://developers.google.com/games/services/downloads/gpg-cpp-sdk.v1.4.1.zip'
+    gpg_sdk_link = 'https://developers.google.com/games/services/downloads/gpg-cpp-sdk.v2.0.zip'
 }
 task download_and_stage_gpg_sdk(dependsOn:'unzip_gpg_sdk') {
 


### PR DESCRIPTION
Hi,

Here is a summary of the changes:
- bumped Google Play Services version to 8.3.0 and Play Games lib version to 2.0
- fixed crash at launch
- bumped gradle version to 2.9
- migrated native dependency declaration to the new gradle system supported in gradle-experimental:0.6.0-alpha2 and cleaned up the app build.gradle accordingly
- added support for all the architectures supported by Google Play Game
  Services

Note: To make it work in Android Studio 2.0, I had to deactive Instant Run for the project.