### PR TITLE
fix static linkage declaration in hello-thirdparty

### DIFF
--- a/hello-thirdparty/app/build.gradle
+++ b/hello-thirdparty/app/build.gradle
@@ -8,12 +8,8 @@ model {
         libs(PrebuiltLibraries) {
             gpg {
                 headers.srcDir "${gpg_sdk_path}/include"
-                binaries.withType(SharedLibraryBinary) {
-                    //
-                    // NOTE: this block should be "StaticLibraryBinary"/staticLibraryFile - but SharedLibraryBinary works and StaticLibraryBinary doesn't as of 0.6.0-alpha2
-                    // bug reported here: https://code.google.com/p/android/issues/detail?id=196065
-                    //
-                    sharedLibraryFile = file("${gpg_sdk_path}/lib/c++/${targetPlatform.getName()}/libgpg.a")
+                binaries.withType(StaticLibraryBinary) {
+                    staticLibraryFile = file("${gpg_sdk_path}/lib/c++/${targetPlatform.getName()}/libgpg.a")
                 }
             }
         }
@@ -45,7 +41,7 @@ model {
         main {
             jni {
                 dependencies {
-                    library "gpg"
+                    library "gpg" linkage "static"
                 }
             }
         }

--- a/hello-thirdparty/build.gradle
+++ b/hello-thirdparty/build.gradle
@@ -4,7 +4,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.6.0-alpha2'
+        classpath 'com.android.tools.build:gradle-experimental:0.6.0-alpha3'
     }
 }
 


### PR DESCRIPTION
The bug https://code.google.com/p/android/issues/detail?id=196065 has been resolved: the linkage type has to be declared at the dependency level too. I've fixed the code accordingly.