### PR TITLE
Remove unnecessary ANativeWindow_SetBuffersGeometry() call.

### DIFF
--- a/MoreTeapots/app/src/main/jni/ndk_helper/GLContext.cpp
+++ b/MoreTeapots/app/src/main/jni/ndk_helper/GLContext.cpp
@@ -134,14 +134,6 @@ bool GLContext::InitEGLSurface()
     eglQuerySurface( display_, surface_, EGL_WIDTH, &screen_width_ );
     eglQuerySurface( display_, surface_, EGL_HEIGHT, &screen_height_ );
 
-    /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-     * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-     * As soon as we picked a EGLConfig, we can safely reconfigure the
-     * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-    EGLint format;
-    eglGetConfigAttrib( display_, config_, EGL_NATIVE_VISUAL_ID, &format );
-    ANativeWindow_setBuffersGeometry( window_, 0, 0, format );
-
     return true;
 }
 

--- a/Teapot/app/src/main/jni/ndk_helper/GLContext.cpp
+++ b/Teapot/app/src/main/jni/ndk_helper/GLContext.cpp
@@ -134,14 +134,6 @@ bool GLContext::InitEGLSurface()
     eglQuerySurface( display_, surface_, EGL_WIDTH, &screen_width_ );
     eglQuerySurface( display_, surface_, EGL_HEIGHT, &screen_height_ );
 
-    /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-     * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-     * As soon as we picked a EGLConfig, we can safely reconfigure the
-     * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-    EGLint format;
-    eglGetConfigAttrib( display_, config_, EGL_NATIVE_VISUAL_ID, &format );
-    ANativeWindow_setBuffersGeometry( window_, 0, 0, format );
-
     return true;
 }
 

--- a/endless-tunnel/app/src/main/jni/native_engine.cpp
+++ b/endless-tunnel/app/src/main/jni/native_engine.cpp
@@ -285,7 +285,7 @@ bool NativeEngine::InitSurface() {
         
     LOGD("NativeEngine: initializing surface.");
     
-    EGLint numConfigs, format;
+    EGLint numConfigs;
 
     const EGLint attribs[] = {
             EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT, // request OpenGL ES 2.0
@@ -300,10 +300,6 @@ bool NativeEngine::InitSurface() {
     // since this is a simple sample, we have a trivial selection process. We pick
     // the first EGLConfig that matches:
     eglChooseConfig(mEglDisplay, attribs, &mEglConfig, 1, &numConfigs);
-
-    // configure native window
-    eglGetConfigAttrib(mEglDisplay, mEglConfig, EGL_NATIVE_VISUAL_ID, &format);
-    ANativeWindow_setBuffersGeometry(mApp->window, 0, 0, format);
 
     // create EGL surface
     mEglSurface = eglCreateWindowSurface(mEglDisplay, mEglConfig, mApp->window, NULL);

--- a/hello-thirdparty/app/src/main/jni/main.cpp
+++ b/hello-thirdparty/app/src/main/jni/main.cpp
@@ -94,7 +94,7 @@ static int engine_init_display(struct engine* engine) {
   const EGLint attribs[] = {EGL_SURFACE_TYPE, EGL_WINDOW_BIT, EGL_BLUE_SIZE,
                             8,                EGL_GREEN_SIZE, 8,
                             EGL_RED_SIZE,     8,              EGL_NONE};
-  EGLint w, h, dummy, format;
+  EGLint w, h, dummy;
   EGLint numConfigs;
   EGLConfig config;
   EGLSurface surface;
@@ -108,14 +108,6 @@ static int engine_init_display(struct engine* engine) {
    * sample, we have a very simplified selection process, where we pick
    * the first EGLConfig that matches our criteria */
   eglChooseConfig(display, attribs, &config, 1, &numConfigs);
-
-  /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-   * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-   * As soon as we picked a EGLConfig, we can safely reconfigure the
-   * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-  eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &format);
-
-  ANativeWindow_setBuffersGeometry(engine->app->window, 0, 0, format);
 
   surface = eglCreateWindowSurface(display, config, engine->app->window, NULL);
   context = eglCreateContext(display, config, NULL, NULL);

--- a/native-activity/app/src/main/jni/main.c
+++ b/native-activity/app/src/main/jni/main.c
@@ -75,7 +75,7 @@ static int engine_init_display(struct engine* engine) {
             EGL_RED_SIZE, 8,
             EGL_NONE
     };
-    EGLint w, h, dummy, format;
+    EGLint w, h, dummy;
     EGLint numConfigs;
     EGLConfig config;
     EGLSurface surface;
@@ -89,14 +89,6 @@ static int engine_init_display(struct engine* engine) {
      * sample, we have a very simplified selection process, where we pick
      * the first EGLConfig that matches our criteria */
     eglChooseConfig(display, attribs, &config, 1, &numConfigs);
-
-    /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-     * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-     * As soon as we picked a EGLConfig, we can safely reconfigure the
-     * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-    eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &format);
-
-    ANativeWindow_setBuffersGeometry(engine->app->window, 0, 0, format);
 
     surface = eglCreateWindowSurface(display, config, engine->app->window, NULL);
     context = eglCreateContext(display, config, NULL, NULL);


### PR DESCRIPTION
- We don't have to call the API unless want to have different buffer size than
  the native resolution.
- This was causing broken rendering on some devices.