### PR TITLE
re-enable native player for native-media

### DIFF
--- a/native-media/README.md
+++ b/native-media/README.md
@@ -31,6 +31,11 @@ Screenshots
 -----------
 ![screenshot](screenshot.png)
 
+
+Known Issues
+------------
+- Android-N preoview: native player path is not working, under debug now
+
 Support
 -------
 If you've found an error in these samples, please [file an issue](https://github.com/googlesamples/android-ndk/issues/new).

--- a/native-media/app/src/main/java/com/example/nativemedia/NativeMedia.java
+++ b/native-media/app/src/main/java/com/example/nativemedia/NativeMedia.java
@@ -262,8 +262,7 @@ public class NativeMedia extends Activity {
                         mNativeMediaPlayerVideoSink = mSelectedVideoSink;
                     }
                     if (mSourceString != null) {
-                        // Temporarily disabling native player, re-enable after debugging
-                        // created = createStreamingMediaPlayer(assetMgr, mSourceString);
+                        created = createStreamingMediaPlayer(assetMgr, mSourceString);
                     }
                 }
                 if (created) {


### PR DESCRIPTION
Since M still works for native player, enable it and added a line in README.md to notify android-N issue. tracking with bug https://code.google.com/p/android/issues/detail?id=209410 and internal bug id 28666655
