### PR TITLE
adding debug related info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ Additional Android Studio samples:
 - [Android Vulkan API Basic Samples](https://github.com/googlesamples/vulkan-basic-samples)
 - [Android High Performance Audio](https://github.com/googlesamples/android-audio-high-performance)	
 
-Known Issues	
+Known Issues
 - Some are documented at [Android Studio](http://tools.android.com/knownissues) page
 - For native application, editing some gradle properties [like sdk version] from Android Studio UI is not supported
 
 For samples using `Android.mk` build system with `ndk-build` see the [android-mk](https://github.com/googlesamples/android-ndk/tree/android-mk) branch.
 
+Debugging
+---------
+- [hello-jni-codelab](https://codelabs.developers.google.com/codelabs/android-studio-jni/index.html?index=..%2F..%2Findex#0)
+- [REFERENCE.md](REFERENCE.md) 
 
 Support
 -------

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,11 @@
+Android Studio/Gradle DSL References    
+
+| Name          |Function   | Type          | Options  | Default |
+|---------------|-----------|:-------------:|----------|---------|
+| debuggable    | Debugging Java code | bool | true / false    ||
+| ndk.debuggable| Debugging JNI code  | bool | true / false    ||    
+
+Notation:    
+&nbsp;&nbsp;&nbsp;&nbsp; dot(".") notation is same as closure ("{}") notation
+
+


### PR DESCRIPTION
1) updated README.md to include hello-jni codelab which includes debug step inside Android Studio
2) added REFERENCE.md to put down gradle debugging flags

This is to solve https://github.com/googlesamples/android-ndk/issues/20
Plan: from here we add important gradle settings into REFERENCE.md, and hope someday it will be a thorough document. The format of the REFERENCE.md might change as we move along, the content should stay relevant.

Please review and comment whether this strategy could satisfy our needs, thank you very much!
