### PR TITLE
Revert platformVersion from Hello-Jni:

### DIFF
--- a/hello-jni/app/build.gradle
+++ b/hello-jni/app/build.gradle
@@ -14,7 +14,6 @@ model {
          * native build settings: taking default for almost everything
          */
         ndk {
-            platformVersion = 9
             moduleName = 'hello-jni'
             toolchain = 'clang'
             CFlags.addAll(['-Wall'])


### PR DESCRIPTION
  if version is too low (lower than the supporting for 64),
  all 64 bit ABI will not build and run anymore.

It is a big problem than just reverting this sample, need find a better way to handle it: one way or the other it has to break someone...