### PR TITLE
removing comment about gradle.properties, no code changes

### DIFF
--- a/native-activity/app/build.gradle
+++ b/native-activity/app/build.gradle
@@ -25,9 +25,7 @@ android {
     }
     // Documentation purpose: app/src/main/jni is reserved for deprecated native build system;
     // Steer away from this directory by DELETING it for ndk-build/cmake + android studio usage.
-    // Otherwise you need to
-    //    add android.useDeprecatedNdk=true to gradle.properties
-    //    enable the following line to silence android studio complaint
+    // Otherwise you need to enable the following line to silence android studio complaint
     // sourceSets.main.jni.srcDirs = []
 }
 

--- a/native-activity/gradle.properties
+++ b/native-activity/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-# android.useDeprecatedNdk=true
+


### PR DESCRIPTION
if we have sourceSets.main.jni.srcDirs = [], then gradle.properties is not needed
