### PR TITLE
remove hard float compiling flags: compiling flags are gone

### DIFF
--- a/MoreTeapots/app/build.gradle
+++ b/MoreTeapots/app/build.gradle
@@ -32,15 +32,6 @@ model {
                              '-fno-exceptions', '-fno-rtti'])
             ldLibs.addAll(['android', 'log', 'EGL', 'GLESv2','atomic'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1',
-                                 '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         sources {
             main {
                 jni {

--- a/Teapot/app/build.gradle
+++ b/Teapot/app/build.gradle
@@ -32,15 +32,6 @@ model {
                              '-fno-exceptions', '-fno-rtti'])
             ldLibs.addAll(['android', 'log', 'EGL', 'GLESv2','atomic'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1',
-                                 '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         sources {
             main {
                 jni {

--- a/choreographer-30fps/app/build.gradle
+++ b/choreographer-30fps/app/build.gradle
@@ -32,15 +32,6 @@ model {
                              '-fno-exceptions', '-fno-rtti'])
             ldLibs.addAll(['android', 'log', 'EGL', 'GLESv2','atomic'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1',
-                                 '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         sources {
             main {
                 jni {

--- a/endless-tunnel/app/build.gradle
+++ b/endless-tunnel/app/build.gradle
@@ -39,14 +39,6 @@ model {
                              '-I' + file('src/main/jni/data')])
             ldLibs.addAll(['android', 'EGL', 'GLESv2', 'OpenSLES', 'log'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1', '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         sources {
             main {
                 jni {

--- a/gles3jni/app/build-11.gradle
+++ b/gles3jni/app/build-11.gradle
@@ -20,14 +20,6 @@ model {
             CFlags.addAll(['-Wall', '-DDYNAMIC_ES3'])
             ldLibs.addAll(['log','GLESv2', 'EGL'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1', '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         buildTypes {
             release {
                 minifyEnabled = false

--- a/gles3jni/app/build-18.gradle
+++ b/gles3jni/app/build-18.gradle
@@ -19,14 +19,6 @@ model {
             CFlags.addAll(['-Wall'])
             ldLibs.addAll(['log','GLESv3', 'EGL'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1', '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         buildTypes {
             release {
                 minifyEnabled = false

--- a/hello-gl2/app/build.gradle
+++ b/hello-gl2/app/build.gradle
@@ -17,14 +17,6 @@ model {
             cppFlags.addAll(['-std=c++11','-Wall'])
             ldLibs.addAll(['log', 'GLESv2'])
         }
-        // Turn on hard float support in armeabi-v7a
-        abis {
-            create('armeabi-v7a') {
-                cppFlags.addAll(['-mhard-float', '-D_NDK_MATH_NO_SOFTFP=1', '-mfloat-abi=hard'])
-                ldLibs.add('m_hard')
-                ldFlags.add('-Wl,--no-warn-mismatch')
-            }
-        }
         buildTypes {
             release {
                 minifyEnabled = false


### PR DESCRIPTION
this is to fix the issue: 
https://github.com/googlesamples/android-ndk/issues/207
there is no such compiling flags anymore in future ndk releases