### PR TITLE
update build to android studio 2.2.0 alpha5.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ local.properties
 build
 *~
 .DS_Store
+externalNativeBuild
+

--- a/audio-echo/app/build.gradle
+++ b/audio-echo/app/build.gradle
@@ -32,3 +32,4 @@ model {
 dependencies {
     compile 'com.android.support:support-v4:23.0.0'
 }
+

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -7,7 +7,7 @@ CMake sample includes 5 independent apps:
 - hello-libs
 - Teapot
 - endless-tunnel
-to demostrate android studio cmake plugin to build native (C/C++) project. Once the project is opened inside android studio 2.2 or better, select anyone you are interested, then build and run on target.
+to demostrate android studio cmake plugin to build native (C/C++) project. Once the project is opened inside android studio 2.2 alpha5 or better(NOTE: 2.2 alpha4 will NOT work anymore), select anyone you are interested, then build and run on target.
 
 Pre-requisites
 --------------

--- a/cmake/Teapot/build.gradle
+++ b/cmake/Teapot/build.gradle
@@ -8,8 +8,10 @@ android {
         applicationId = 'com.sample.teapot'
         minSdkVersion 17
         targetSdkVersion 22
-        cmake {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+        externalNativeBuild {
+            cmake {
+                abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            }
         }
     }
     buildTypes {

--- a/cmake/build.gradle
+++ b/cmake/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/cmake/endless-tunnel/build.gradle
+++ b/cmake/endless-tunnel/build.gradle
@@ -26,8 +26,10 @@ android {
         targetSdkVersion 22
         versionCode     1
         versionName    '1.0'
-        cmake {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+        externalNativeBuild {
+            cmake {
+                abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            }
         }
     }
     buildTypes {

--- a/cmake/hello-jni/build.gradle
+++ b/cmake/hello-jni/build.gradle
@@ -9,8 +9,10 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
-        cmake {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+        externalNativeBuild {
+            cmake {
+                abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            }
         }
     }
     buildTypes {
@@ -24,12 +26,6 @@ android {
             path "src/main/cpp/CMakeLists.txt"
         }
     }
-    // Documentation purpose: app/src/main/jni is reserved for deprecated native build system;
-    // Steer away from this directory by DELETING it for ndk-build/cmake + android studio usage.
-    // Otherwise you need to
-    //    add android.useDeprecatedNdk=true to gradle.properties
-    //    enable the following line to silence android studio complaint
-    // sourceSets.main.jni.srcDirs = []
 }
 
 dependencies {

--- a/cmake/hello-jniCallback/build.gradle
+++ b/cmake/hello-jniCallback/build.gradle
@@ -9,8 +9,10 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
-        cmake {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+        externalNativeBuild {
+            cmake {
+                abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            }
         }
     }
     buildTypes {

--- a/cmake/hello-libs/build.gradle
+++ b/cmake/hello-libs/build.gradle
@@ -10,8 +10,10 @@ apply plugin: 'com.android.application'
             targetSdkVersion 23
             versionCode = 1
             versionName = '1.0'
-            cmake {
-                abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            externalNativeBuild {
+                cmake {
+                    abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+                }
             }
         }
         sourceSets {


### PR DESCRIPTION
 It is not-backward compatible for cmake project:
    with android studio 2.2.0 alpha1 -- alpha4:  use code before this checkin
    with android studio 2.2.0 alpha5 and after:     this checkin and after