### PR TITLE
fixed issue https://github.com/googlesamples/android-ndk/issues/263:

### DIFF
--- a/hello-libs/app/src/main/cpp/hello-libs.cpp
+++ b/hello-libs/app/src/main/cpp/hello-libs.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  *
  */
-#include <string.h>
+#include <cstring>
 #include <jni.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <android/log.h>
 #include <gmath.h>
 #include <gperf.h>


### PR DESCRIPTION
using standard C++ headers, instead of c headers to fix PRIu64 issue