### PR TITLE
Resolve UnsatisfiedLinkError from bad abiFilter

### DIFF
--- a/hello-libs/app/build.gradle
+++ b/hello-libs/app/build.gradle
@@ -50,8 +50,33 @@ model {
             stl = 'gnustl_static'
             cppFlags.addAll(['-std=c++11'])
             ldLibs.addAll(['android', 'log'])
-            // build a default combined apk including all ABIs.
-            // abiFilters.addAll(['x86'])
+        }
+        productFlavors {
+            // for detailed abiFilter descriptions, refer to "Supported ABIs" @
+            // https://developer.android.com/ndk/guides/abis.html#sa
+            create("arm") {
+                ndk.abiFilters.add("armeabi")
+            }
+            create("arm7") {
+                ndk.abiFilters.add("armeabi-v7a")
+            }
+            create("arm8") {
+                ndk.abiFilters.add("arm64-v8a")
+            }
+            create("x86") {
+                ndk.abiFilters.add("x86")
+            }
+            create("x86-64") {
+                ndk.abiFilters.add("x86_64")
+            }
+            create("mips") {
+                ndk.abiFilters.add("mips")
+            }
+            create("mips-64") {
+                ndk.abiFilters.add("mips64")
+            }
+            // To include all cpu architectures, leaves abiFilters empty
+            create("all")
         }
         sources {
             main {


### PR DESCRIPTION
The app crashes on launch with error:

java.lang.UnsatisfiedLinkError: dalvik.system.PathClassLoader[DexPathList[[zip file "/data/app/com.example.hellolibs-1/base.apk"],nativeLibraryDirectories=[/data/app/com.example.hellolibs-1/lib/x86_64, /vendor/lib64, /system/lib64]]] couldn't find "libhello-libs.so"

Copying abiFilter creation from "Hello-JNI" app build.gradle resolves this issue.