### PR TITLE
Fix an outdated link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ NDK Samples [![Build Status](https://travis-ci.org/googlesamples/android-ndk.svg
 
 This repository contains [Android NDK][0] samples with Android Studio [C++ integration](https://www.youtube.com/watch?v=f7ihSQ44WO0&feature=youtu.be).
 
-These samples uses the new [CMake Android plugin](http://tools.android.com/tech-docs/external-c-builds) with C++ support.
+These samples uses the new [CMake Android plugin](https://developer.android.com/studio/projects/add-native-code.html) with C++ support.
 
 Additional Android Studio samples:    
 - [Google Play Game Samples with Android Studio](https://github.com/playgameservices/cpp-android-basic-samples)
@@ -19,7 +19,7 @@ For samples using `Android.mk` build system with `ndk-build` see the [android-mk
 
 Build Steps
 ----------
-- With Android Studio: use "Import Project(Eclipse ADT, Gradle, etc)" or "File" > "Import Projec"t option
+- With Android Studio: use "Import Project(Eclipse ADT, Gradle, etc)" or "File" > "Import Project" option
 - On Command Line/Terminal:  make sure set up ANDROID_HOME and ANDROID_NDK_HOME to local installation of SDK and NDK, then go to individual sample dir, and use "gradlew assembleDebug"
  
 Support


### PR DESCRIPTION
http://tools.android.com/tech-docs/external-c-builds has a redirector gadget. The gadget is broken, but the source has a reference to https://developer.android.com/studio/projects/add-native-code.html, so I guess that's the right place.