### PR TITLE
Fix unified header related issues:

### DIFF
--- a/audio-echo/app/src/main/cpp/audio_common.h
+++ b/audio-echo/app/src/main/cpp/audio_common.h
@@ -18,6 +18,7 @@
 #ifndef NATIVE_AUDIO_AUDIO_COMMON_H
 #define NATIVE_AUDIO_AUDIO_COMMON_H
 
+#include <SLES/OpenSLES.h>
 #include <SLES/OpenSLES_Android.h>
 
 #include "android_debug.h"

--- a/audio-echo/app/src/main/cpp/audio_player.h
+++ b/audio-echo/app/src/main/cpp/audio_player.h
@@ -17,7 +17,6 @@
 #ifndef NATIVE_AUDIO_AUDIO_PLAYER_H
 #define NATIVE_AUDIO_AUDIO_PLAYER_H
 #include <sys/types.h>
-#include <SLES/OpenSLES_Android.h>
 #include "audio_common.h"
 #include "buf_manager.h"
 #include "debug_utils.h"

--- a/endless-tunnel/app/src/main/cpp/common.hpp
+++ b/endless-tunnel/app/src/main/cpp/common.hpp
@@ -25,6 +25,7 @@ extern "C" {
     #include <android/log.h>
     #include <android_native_app_glue.h>
     #include <unistd.h>
+    #include <stdlib.h>
 }
 #include "glm/glm.hpp"
 #include "glm/gtc/type_ptr.hpp"

--- a/native-activity/app/src/main/cpp/main.cpp
+++ b/native-activity/app/src/main/cpp/main.cpp
@@ -18,6 +18,7 @@
 //BEGIN_INCLUDE(all)
 #include <initializer_list>
 #include <memory>
+#include <cstdlib>
 #include <jni.h>
 #include <errno.h>
 #include <cassert>

--- a/teapots/common/ndk_helper/shader.cpp
+++ b/teapots/common/ndk_helper/shader.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#include <cstdlib>
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 


### PR DESCRIPTION
  1) included OpenSLES.h BEFORE OpenSLES_Android.h
       OpenSLES.h inclusion is removed from OpenSLES_Abndroid.h
  2) added stdlib.h/cstdlib concerning malloc for sample
       endless tunnel
       native-activity
       teapots derivative samples

Related info: 
 https://android.googlesource.com/platform/ndk.git/+/ndk-r14-release/docs/UnifiedHeaders.md

@hak @bbilodeau @qchong @DanAlbert please help take a look, thanks!
