### PR TITLE
change isnan() to isnanf(): unified headers does not support it

### DIFF
--- a/teapots/common/ndk_helper/tapCamera.cpp
+++ b/teapots/common/ndk_helper/tapCamera.cpp
@@ -269,7 +269,7 @@ void TapCamera::Pinch(const Vec2& v1, const Vec2& v2) {
     f = -1.f / f + 1.0f;
   else
     f = f - 1.f;
-  if (isnan(f)) f = 0.f;
+  if (isnanf(f)) f = 0.f;
 
   vec = (v1 + v2) / 2.f - vec_pinch_start_center_;
   vec_offset_now_ = Vec3(vec, flip_z_ * f);

--- a/teapots/common/ndk_helper/vecmath.h
+++ b/teapots/common/ndk_helper/vecmath.h
@@ -189,7 +189,7 @@ class Vec2 {
   float Dot(const Vec2& rhs) { return x_ * rhs.x_ + y_ * rhs.y_; }
 
   bool Validate() {
-    if (isnan(x_) || isnan(y_)) return false;
+    if (isnanf(x_) || isnanf(y_)) return false;
     return true;
   }
 
@@ -386,7 +386,7 @@ class Vec3 {
   }
 
   bool Validate() {
-    if (isnan(x_) || isnan(y_) || isnan(z_)) return false;
+    if (isnanf(x_) || isnanf(y_) || isnanf(z_)) return false;
     return true;
   }
 
@@ -604,7 +604,7 @@ class Vec4 {
   }
 
   bool Validate() {
-    if (isnan(x_) || isnan(y_) || isnan(z_) || isnan(w_)) return false;
+    if (isnanf(x_) || isnanf(y_) || isnanf(z_) || isnanf(w_)) return false;
     return true;
   }
 


### PR DESCRIPTION
need to find out reason later  -- isnan() is a standard function, isnanf() is NOT standard function to use
http://www.cplusplus.com/reference/cmath/isnan/?kw=isnan

@danalbert, @qchong , @bbilodeau  please take a look, thanks

