### PR TITLE
Use clang to build teapot samples

### DIFF
--- a/teapots/choreographer-30fps/build.gradle
+++ b/teapots/choreographer-30fps/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 
      defaultConfig {
          applicationId 'com.sample.choreographer'
-         minSdkVersion 16
+         minSdkVersion 21
          targetSdkVersion 25
          ndk {
              abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'

--- a/teapots/more-teapots/build.gradle
+++ b/teapots/more-teapots/build.gradle
@@ -7,15 +7,15 @@ android {
 
     defaultConfig {
         applicationId  'com.sample.moreteapots'
-        minSdkVersion   17
+        minSdkVersion   21
         targetSdkVersion 25
         ndk {
             abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a','x86'
         }
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_PLATFORM=android-22',
-                    '-DANDROID_TOOLCHAIN=gcc', '-DANDROID_STL=c++_static'
+                arguments '-DANDROID_PLATFORM=android-21',
+                    '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static'
             }
         }
     }


### PR DESCRIPTION
removing gcc: it is not supported
@bbilodeau @danalbert, please have review, thank you!