### PR TITLE
Update hello-cdep to include all ABIs

### DIFF
--- a/hello-cdep/README.md
+++ b/hello-cdep/README.md
@@ -8,7 +8,7 @@ This sample uses the new [Android Studio CMake plugin](http://tools.android.com/
 * How to use external pre-build libs packed inside [CDep](https://github.com/google/cdep) package
 
 Refer to [CDep documentation](http://github.com/google/cdep/blob/master/README.md)
-The lib binaries and header files are hosted in [temporary repo](https://github.com/ggfan/hello-libs), this sample use 
+The lib binaries and header files are hosted in [temporary repo](https://github.com/ggfan/hello-CDep/releases), this sample uses 
 [CDep](https://github.com/google/cdep) to pull it into Android Studio's [cmake](https://cmake.org/documentation) script.
 
 Pre-requisites
@@ -19,7 +19,10 @@ Getting Started
 1. [Download Android Studio](http://developer.android.com/sdk/index.html)
 1. Launch Android Studio.
 1. Download cdep dependences:
-* inside terminal, cd ${PROJECT_DIR}; ./cdep
+* inside terminal
+```
+    cd ${PROJECT_DIR}; ./cdep
+```
 1. Open the sample directory.
 1. Open *File/Project Structure...*
   - Click *Download* or *Select NDK location*.

--- a/hello-cdep/app/build.gradle
+++ b/hello-cdep/app/build.gradle
@@ -11,8 +11,7 @@ android {
         versionCode = 1
         versionName = '1.0'
         ndk {
-            //TODO: add support x86
-            abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         }
         externalNativeBuild {
             cmake {

--- a/hello-cdep/app/src/main/cpp/hello-cdep.cpp
+++ b/hello-cdep/app/src/main/cpp/hello-cdep.cpp
@@ -23,7 +23,7 @@
 
 
 #define LOGI(...) \
-  ((void)__android_log_print(ANDROID_LOG_INFO, "hell-libs::", __VA_ARGS__))
+  ((void)__android_log_print(ANDROID_LOG_INFO, "hell-cdep::", __VA_ARGS__))
 
 /* This is a trivial JNI example where we use a native method
  * to return a new VM String. See the corresponding Java source

--- a/hello-cdep/cdep.yml
+++ b/hello-cdep/cdep.yml
@@ -1,4 +1,4 @@
 builders: [cmake]
 
 dependencies:
-- compile: com.github.ggfan:hello-libs:0.0.0
+- compile: com.github.ggfan:hello-cdep:1.0.0


### PR DESCRIPTION
quick update for hello-CDep for x86 ABIs, and also changes hosting repo to "hello-cdep"