### PR TITLE
Request an ES3 context, not an ES2 context.

### DIFF
--- a/gles3jni/app/src/main/java/com/android/gles3jni/GLES3JNIView.java
+++ b/gles3jni/app/src/main/java/com/android/gles3jni/GLES3JNIView.java
@@ -39,7 +39,7 @@ class GLES3JNIView extends GLSurfaceView {
         // Pick an EGLConfig with RGB8 color, 16-bit depth, no stencil,
         // supporting OpenGL ES 2.0 or later backwards-compatible versions.
         setEGLConfigChooser(8, 8, 8, 0, 16, 0);
-        setEGLContextClientVersion(2);
+        setEGLContextClientVersion(3);
         setRenderer(new Renderer());
     }
 


### PR DESCRIPTION
This will fix issue #398 

This example is supposed to show how to use GL ES3 rendering.
Yet, it will only request GL ES2 contexts, so never actually creates an ES3 Renderer object.

By selecting the correct GL ES Context, the app will now properly use the ES3 rendering code.