### PR TITLE
Add google maven repository declaration

### DIFF
--- a/teapots/build.gradle
+++ b/teapots/build.gradle
@@ -11,5 +11,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }


### PR DESCRIPTION
com.android.support:appcompat-v7 is no longer available
on the Android SDK off-line repository, it needs to be
downloaded from the google online repository instead