### PR TITLE
pass choreopher timestamp from java to jni to get correct 30 fps

### DIFF
--- a/teapots/choreographer-30fps/build.gradle
+++ b/teapots/choreographer-30fps/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 
      defaultConfig {
          applicationId 'com.sample.choreographer'
-         minSdkVersion 21
+         minSdkVersion 16
          targetSdkVersion 25
          ndk {
              abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
@@ -14,7 +14,7 @@ apply plugin: 'com.android.application'
          externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=gnustl_static',
-                          '-DANDROID_PLATFORM=android-21'
+                          '-DANDROID_PLATFORM=android-16'
             }
          }
      }

--- a/teapots/choreographer-30fps/src/main/cpp/ChoreographerNativeActivity.cpp
+++ b/teapots/choreographer-30fps/src/main/cpp/ChoreographerNativeActivity.cpp
@@ -126,7 +126,7 @@ class Engine {
 
   // Do swap operation while Choreographer callback. Need to be a public method
   // since it's called from JNI callback.
-  void SynchInCallback();
+  void SynchInCallback(jlong frameTimeNamos);
 };
 
 // Global instance of the Engine class.
@@ -292,19 +292,18 @@ void Engine::StopJavaChoreographer() {
   return;
 }
 
-void Engine::SynchInCallback() {
+void Engine::SynchInCallback(jlong frameTimeInNanos) {
   // Signal render thread if the render cycle meet the condition.
-  int64_t cur  = GetCurrentTime();
-  if (COULD_RENDER(cur, prevFrameTimeNanos_)) {
-    prevFrameTimeNanos_ = cur;
+  if (COULD_RENDER(frameTimeInNanos, prevFrameTimeNanos_)) {
+    prevFrameTimeNanos_ = frameTimeInNanos;
     cv_.notify_one();
   }
 };
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_sample_choreographer_ChoreographerNativeActivity_choregrapherCallback(
-    JNIEnv* env, jobject instance) {
-  g_engine.SynchInCallback();
+    JNIEnv* env, jobject instance, jlong frameTimeInNanos) {
+  g_engine.SynchInCallback(frameTimeInNanos);
 }
 
 // Helper functions.

--- a/teapots/choreographer-30fps/src/main/java/com/sample/choreographer/ChoreographerNativeActivity.java
+++ b/teapots/choreographer-30fps/src/main/java/com/sample/choreographer/ChoreographerNativeActivity.java
@@ -46,7 +46,7 @@ public class ChoreographerNativeActivity extends NativeActivity
     @Override
     public void doFrame(long frameTimeNanos) {
         Choreographer.getInstance().postFrameCallback(this);
-        choregrapherCallback();
+        choregrapherCallback(frameTimeNanos);
     }
 
     @TargetApi(16)
@@ -61,7 +61,7 @@ public class ChoreographerNativeActivity extends NativeActivity
         use_choreographer = false;
     }
 
-    protected native void choregrapherCallback();
+    protected native void choregrapherCallback(long frameTimeNamos);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Timestamp from vblank needs to pass from Java side to JNI on API-16/17/18 to get the correct rendering frames.

@bbilodeau  please take a look, thanks!