### PR TITLE
Camera: added GetLatestImage method

### DIFF
--- a/camera/basic/src/main/cpp/image_reader.cpp
+++ b/camera/basic/src/main/cpp/image_reader.cpp
@@ -107,8 +107,7 @@ ANativeWindow *ImageReader::GetNativeWindow(void) {
 /**
  * GetNextImage()
  *   Retrieve the next image in ImageReader's bufferQueue, NOT the last image so
- * no image is
- *   skipped
+ * no image is skipped. Recommended for batch/background processing.
  */
 AImage *ImageReader::GetNextImage(void) {
   AImage *image;
@@ -117,6 +116,20 @@ AImage *ImageReader::GetNextImage(void) {
     return nullptr;
   }
   return image;
+}
+
+/**
+ * GetLatestImage()
+ *   Retrieve the last image in ImageReader's bufferQueue, deleting images in
+ * in front of it on the queue. Recommended for real-time processing.
+ */
+AImage *ImageReader::GetLatestImage(void) {
+    AImage *image;
+    media_status_t status = AImageReader_acquireLatestImage(reader_, &image);
+    if (status != AMEDIA_OK) {
+        return nullptr;
+    }
+    return image;
 }
 
 /**

--- a/camera/basic/src/main/cpp/image_reader.h
+++ b/camera/basic/src/main/cpp/image_reader.h
@@ -51,6 +51,11 @@ class ImageReader {
   AImage* GetNextImage(void);
 
   /**
+  * Retrieve Image on the back of Reader's queue, dropping older images
+  */
+  AImage* GetLatestImage(void);
+
+  /**
    * Delete Image
    * @param image {@link AImage} instance to be deleted
    */


### PR DESCRIPTION
As this being a very main source for anyone learning to use the Native Camera API calls it would be nice to show more information that if they plan to do real time processing that they should not be using `AImageReader_acquireNextImage` as it will cause huge delay when scaling up resolution of preview. Just adding the extra comment and function can help prevent searching and trying to debug why there is such a random image delay