### PR TITLE
destroy the thread attributes properly

### DIFF
--- a/hello-jniCallback/app/src/main/cpp/hello-jnicallback.c
+++ b/hello-jniCallback/app/src/main/cpp/hello-jnicallback.c
@@ -271,6 +271,9 @@ Java_com_example_hellojnicallback_MainActivity_startTicks(JNIEnv *env, jobject i
 
     int result  = pthread_create( &threadInfo_, &threadAttr_, UpdateTicks, &g_ctx);
     assert(result == 0);
+
+    pthread_attr_destroy(&threadAttr_);
+
     (void)result;
 }
 


### PR DESCRIPTION
The ```pthread_attr_t``` struct should be destroyed properly.