### PR TITLE
Update build for Android Studio 3.0

### DIFF
--- a/hello-jni/app/build.gradle
+++ b/hello-jni/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId 'com.example.hellojni'
         minSdkVersion 23
@@ -26,39 +25,47 @@ android {
             path "src/main/cpp/CMakeLists.txt"
         }
     }
+
+    flavorDimensions 'cpuArch'
     productFlavors {
         arm7 {
-            // in the future, ndk.abiFilter might also work
+            dimension 'cpuArch'
             ndk {
                 abiFilter 'armeabi-v7a'
             }
         }
         arm8 {
+            dimension 'cpuArch'
             ndk {
                 abiFilters 'arm64-v8a'
             }
         }
         arm {
+            dimension 'cpuArch'
             ndk {
                 abiFilter 'armeabi'
             }
         }
         x86 {
+            dimension 'cpuArch'
             ndk {
                 abiFilter 'x86'
             }
         }
         x86_64 {
+            dimension 'cpuArch'
             ndk {
                 abiFilter 'x86_64'
             }
         }
         mips {
+            dimension 'cpuArch'
             ndk {
                 abiFilters 'mips', 'mips64'
             }
         }
         universal {
+            dimension 'cpuArch'
             ndk {
                 abiFilters 'mips', 'mips64', 'x86', 'x86_64'
             }
@@ -68,6 +75,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
 }

--- a/hello-jni/build.gradle
+++ b/hello-jni/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/hello-jni/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-jni/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 05 19:05:18 IST 2017
+#Mon Oct 30 21:37:25 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
adding '[flavorDimensions](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html?utm_source=android-studio#variant_aware)' for for hello-jni for Android Studio 3.0 requirements. @rschiu, @jomof, @qchong may you kindly take a look?