### PR TITLE
add abspath workaround for windows ndk-build projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This repository contains [Android NDK][0] samples with Android Studio [C++ integ
 
 These samples uses the new [CMake Android plugin](https://developer.android.com/studio/projects/add-native-code.html) with C++ support.
 
+Samples could also be built with other build systems:
+- for ndk-build with Android Studio, refer to directory [other-builds/ndkbuild](https://github.com/googlesamples/android-ndk/tree/master/other-builds/ndkbuild)
+- for gradle-experimental plugin, refer to directory other-builds/experimental. Note that gradle-experiemental could not work with unified headers yet: use NDK version up to r15 and Android Studio up to version 2.3
+
 Additional Android Studio samples:    
 - [Google Play Game Samples with Android Studio](https://github.com/playgameservices/cpp-android-basic-samples)
 - [Google Android Vulkan Tutorials](https://github.com/googlesamples/android-vulkan-tutorials)

--- a/other-builds/ndkbuild/bitmap-plasma/app/Android.mk
+++ b/other-builds/ndkbuild/bitmap-plasma/app/Android.mk
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
 PROJECT_DIR :=bitmap-plasma
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../$(PROJECT_DIR)/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../$(PROJECT_DIR)/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/gles3jni/app/Android.mk
+++ b/other-builds/ndkbuild/gles3jni/app/Android.mk
@@ -14,7 +14,9 @@
 LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../gles3jni/app/src/main/cpp
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../gles3jni/app/src/main/cpp)
 
 LOCAL_MODULE    := libgles3jni
 LOCAL_CPPFLAGS    := -Werror -std=c++11 -fno-rtti -fno-exceptions -Wall

--- a/other-builds/ndkbuild/hello-gl2/app/Android.mk
+++ b/other-builds/ndkbuild/hello-gl2/app/Android.mk
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH:= $(call my-dir)
 
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../hello-gl2/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-gl2/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/hello-jni/app/Android.mk
+++ b/other-builds/ndkbuild/hello-jni/app/Android.mk
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../hello-jni/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-jni/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/hello-libs/app/Android.mk
+++ b/other-builds/ndkbuild/hello-libs/app/Android.mk
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../hello-libs/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-libs/app/src/main/cpp)
 include $(CLEAR_VARS)
 
 # config distributed lib path
-EXT_LIB_ROOT := $(LOCAL_PATH)/../../../../hello-libs/distribution
+EXT_LIB_ROOT := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-libs/distribution)
 
 # import 2 libs: remember to generate them SEPARATELY in terminal/command line first!
 LOCAL_MODULE := local_gmath

--- a/other-builds/ndkbuild/hello-neon/app/Android.mk
+++ b/other-builds/ndkbuild/hello-neon/app/Android.mk
@@ -1,5 +1,7 @@
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../hello-neon/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-neon/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/native-activity/app/Android.mk
+++ b/other-builds/ndkbuild/native-activity/app/Android.mk
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../native-activity/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa,$(LOCAL_PATH)/../../../../native-activity/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/native-audio/app/Android.mk
+++ b/other-builds/ndkbuild/native-audio/app/Android.mk
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../native-audio/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-audio/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/native-codec/app/Android.mk
+++ b/other-builds/ndkbuild/native-codec/app/Android.mk
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../native-codec/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-codec/app/src/main/cpp)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := native-codec-jni

--- a/other-builds/ndkbuild/native-media/app/Android.mk
+++ b/other-builds/ndkbuild/native-media/app/Android.mk
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../native-media/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-media/app/src/main/cpp)
 
 LOCAL_MODULE    := native-media-jni
 LOCAL_SRC_FILES := $(JNI_SRC_PATH)/native-media-jni.c \

--- a/other-builds/ndkbuild/native-plasma/app/Android.mk
+++ b/other-builds/ndkbuild/native-plasma/app/Android.mk
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../native-plasma/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-plasma/app/src/main/cpp)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := native-plasma

--- a/other-builds/ndkbuild/san-angeles/app/Android.mk
+++ b/other-builds/ndkbuild/san-angeles/app/Android.mk
@@ -1,5 +1,7 @@
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../san-angeles/app/src/main/cpp
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../san-angeles/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/teapots/classic-teapot/Android.mk
+++ b/other-builds/ndkbuild/teapots/classic-teapot/Android.mk
@@ -1,7 +1,9 @@
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
 
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../teapots/classic-teapot/src/main/cpp
-NDK_HELPER_SRC :=$(LOCAL_PATH)/../../../../teapots/common/ndk_helper
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/classic-teapot/src/main/cpp)
+NDK_HELPER_SRC :=$(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/common/ndk_helper)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/teapots/more-teapots/Android.mk
+++ b/other-builds/ndkbuild/teapots/more-teapots/Android.mk
@@ -1,7 +1,9 @@
+abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
 LOCAL_PATH := $(call my-dir)
 
-JNI_SRC_PATH := $(LOCAL_PATH)/../../../../teapots/more-teapots/src/main/cpp
-NDK_HELPER_SRC := $(LOCAL_PATH)/../../../../teapots/common/ndk_helper
+JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/more-teapots/src/main/cpp)
+NDK_HELPER_SRC := $(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/common/ndk_helper)
 
 include $(CLEAR_VARS)
 


### PR DESCRIPTION
tested: Windows & Mac OS

This is mainly to fix ndk-build under windows. The 240 is magic number for file path, abspath helps. refer to:
  http://gnu-make.2324884.n4.nabble.com/using-realpath-abspath-in-3-81-td13798.html
at the bottom of the thread is the workaround, works fine for this case.

