### PR TITLE
Minor update gles3jni to use version 3.2 headers for API 24+

### DIFF
--- a/gles3jni/app/build.gradle
+++ b/gles3jni/app/build.gradle
@@ -1,17 +1,18 @@
 apply plugin: 'com.android.application'
 
-def platformVersion = 18    //openGLES 3 min Version
-//def platformVersion = 12 //openGLES 2 min version
+def platformVersion = 24      // openGLES 3.2 min api level
+// def platformVersion = 18    //openGLES 3 min api level
+// def platformVersion = 12    //openGLES 2 min api level
 
 android {
     compileSdkVersion 25
 
     defaultConfig {
         applicationId 'com.android.gles3jni'
-        minSdkVersion 18
+        minSdkVersion "${platformVersion}"
         targetSdkVersion 25
         ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
         externalNativeBuild {
             cmake {
@@ -36,5 +37,3 @@ android {
         }
     }
 }
-
-

--- a/gles3jni/app/src/main/cpp/gles3jni.h
+++ b/gles3jni/app/src/main/cpp/gles3jni.h
@@ -23,7 +23,15 @@
 #if DYNAMIC_ES3
 #include "gl3stub.h"
 #else
+// Include the latest possible header file( GL version header )
+#if __ANDROID_API__ >= 24
+#include <GLES3/gl32.h>
+#elif __ANDROID_API__ >= 21
+#include <GLES3/gl31.h>
+#else
 #include <GLES3/gl3.h>
+#endif
+
 #endif
 
 #define DEBUG 1


### PR DESCRIPTION
mainly to address issue: https://github.com/googlesamples/android-ndk/issues/350
There is validation usage for various ndk versions, but the sample content no change ( not exploring any of the new functionalities inside gles32)
