### PR TITLE
Set float when requesting FP16 pixel format

### DIFF
--- a/display-p3/image-view/src/main/cpp/WideColorCtx.cpp
+++ b/display-p3/image-view/src/main/cpp/WideColorCtx.cpp
@@ -87,9 +87,12 @@ bool ImageViewEngine::CreateWideColorCtx(WIDECOLOR_MODE mode) {
   };
 
   // for RGBA888, still set to EGL_COLOR_COMPONENT_TYPE_FIXED_EXT?
-  if (mode == WIDECOLOR_MODE::P3_R10G10B10A2_REV) {
+  if (mode == WIDECOLOR_MODE::P3_FP16) {
     attributes.push_back(EGL_COLOR_COMPONENT_TYPE_EXT);
     attributes.push_back(EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT);
+  } else {
+    attributes.push_back(EGL_COLOR_COMPONENT_TYPE_EXT);
+    attributes.push_back(EGL_COLOR_COMPONENT_TYPE_FIXED_EXT);
   }
   attributes.push_back(EGL_NONE);
 


### PR DESCRIPTION
Set color component type to fload for FP16 not 10:10:10:2.
Also set color component type to fixed for all other modes just to
be complete.