### PR TITLE
Remove mips from san-angeles' ABI list.

### DIFF
--- a/san-angeles/app/build.gradle
+++ b/san-angeles/app/build.gradle
@@ -31,7 +31,7 @@ android {
         abi {
             enable true
             reset()
-            include 'armeabi-v7a', 'arm64-v8a','mips', 'x86'
+            include 'armeabi-v7a', 'arm64-v8a', 'x86'
             universalApk false
         }
     }


### PR DESCRIPTION
The ndk-build version of this sample already has this list of ABIs:

    include 'armeabi-v7a', 'arm64-v8a', 'x86'

Bug: https://github.com/googlesamples/android-ndk/issues/505