### PR TITLE
Removed native-activity & endless-tunnel from Java sample list

### DIFF
--- a/endless-tunnel/.google/packaging.yaml
+++ b/endless-tunnel/.google/packaging.yaml
@@ -1,7 +1,7 @@
 status:       PUBLISHED
 technologies: [Android, NDK]
 categories:   [NDK]
-languages:    [C++, Java]
+languages:    [C++]
 solutions:    [Mobile]
 github:       googlesamples/android-ndk
 license:      apache2

--- a/native-activity/.google/packaging.yaml
+++ b/native-activity/.google/packaging.yaml
@@ -1,7 +1,7 @@
 status:       PUBLISHED
 technologies: [Android, NDK]
 categories:   [NDK]
-languages:    [C++, Java]
+languages:    [C++]
 solutions:    [Mobile]
 github:       googlesamples/android-ndk
 license:      apache2

--- a/native-plasma/.google/packaging.yaml
+++ b/native-plasma/.google/packaging.yaml
@@ -1,7 +1,7 @@
 status:       PUBLISHED
 technologies: [Android, NDK]
 categories:   [NDK]
-languages:    [C++, Java]
+languages:    [C++]
 solutions:    [Mobile]
 github:       googlesamples/android-ndk
 license:      apache2

--- a/webp/.google/packaging.yaml
+++ b/webp/.google/packaging.yaml
@@ -1,7 +1,7 @@
 status:       PUBLISHED
 technologies: [Android, NDK]
 categories:   [NDK]
-languages:    [C++, Java]
+languages:    [C++]
 solutions:    [Mobile]
 github:       googlesamples/android-ndk
 license:      apache2


### PR DESCRIPTION
Related bug: b2/78915221