### PR TITLE
Clone 1.0.0 branch of libwebp instead of master

### DIFF
--- a/webp/view/src/main/cpp/CMakeLists.txt
+++ b/webp/view/src/main/cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ set(WEBP_SRC_DIR ${WEBP_SAMPLE_PROJ_DIR}/libwebp)
 #     Android Studio's "Import Android code sample" option
 if ((NOT EXISTS ${WEBP_SRC_DIR}) OR
     (NOT EXISTS ${WEBP_SRC_DIR}/CMakeLists.txt))
-    execute_process(COMMAND git clone
+    execute_process(COMMAND git clone -b 1.0.0
                             https://chromium.googlesource.com/webm/libwebp
                             libwebp
                     WORKING_DIRECTORY ${WEBP_SAMPLE_PROJ_DIR}/)


### PR DESCRIPTION
The master branch fails to build for me atm. In general I think it's a good idea to stick to a specific version, as the master branch might not be stable enough and to make the build reproducible.