### PR TITLE
Fix unnecessary re-build for ndk_helper under teapots sample

### DIFF
--- a/teapots/choreographer-30fps/src/main/cpp/CMakeLists.txt
+++ b/teapots/choreographer-30fps/src/main/cpp/CMakeLists.txt
@@ -20,11 +20,10 @@ project(ChoreographerNativeActivity LANGUAGES C CXX)
 # set up common compile options
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -fno-exceptions -fno-rtti")
 
-# build the ndk-helper library into a common directory
-# visible to all 3 projects avoiding duplicate builds.
+# build the ndk-helper library
 get_filename_component(ndkHelperSrc ../../../../common/ndk_helper ABSOLUTE)
-get_filename_component(ndkHelperBin ${ndkHelperSrc}/../ndkHelperBin ABSOLUTE)
-add_subdirectory(${ndkHelperSrc} ${ndkHelperBin})
+add_subdirectory(${ndkHelperSrc}
+  ${CMAKE_BINARY_DIR}/ndkHelperBin)
 
 # now build app's shared lib
 add_library(${PROJECT_NAME}

--- a/teapots/classic-teapot/src/main/cpp/CMakeLists.txt
+++ b/teapots/classic-teapot/src/main/cpp/CMakeLists.txt
@@ -20,11 +20,10 @@ project(TeapotNativeActivity LANGUAGES C CXX)
 # set up common compile options
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -fno-exceptions -fno-rtti")
 
-# build the ndk-helper library into a common directory
-# visible to all 3 projects avoiding duplicate builds.
+# build the ndk-helper library
 get_filename_component(ndkHelperSrc ../../../../common/ndk_helper ABSOLUTE)
-get_filename_component(ndkHelperBin ${ndkHelperSrc}/../ndkHelperBin ABSOLUTE)
-add_subdirectory(${ndkHelperSrc} ${ndkHelperBin})
+add_subdirectory(${ndkHelperSrc}
+  ${CMAKE_BINARY_DIR}/ndkHelperBin)
 
 # now build app's shared lib
 add_library(${PROJECT_NAME}

--- a/teapots/more-teapots/src/main/cpp/CMakeLists.txt
+++ b/teapots/more-teapots/src/main/cpp/CMakeLists.txt
@@ -20,11 +20,10 @@ project(MoreTeapotsNativeActivity LANGUAGES C CXX)
 # set up common compile options
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -fno-exceptions -fno-rtti")
 
-# build the ndk-helper library into a common directory
-# visible to all 3 projects avoiding duplicate builds.
+# build the ndk-helper library
 get_filename_component(ndkHelperSrc ../../../../common/ndk_helper ABSOLUTE)
-get_filename_component(ndkHelperBin ${ndkHelperSrc}/../ndkHelperBin ABSOLUTE)
-add_subdirectory(${ndkHelperSrc} ${ndkHelperBin})
+add_subdirectory(${ndkHelperSrc}
+  ${CMAKE_BINARY_DIR}/ndkHelperBin)
 
 # now build app's shared lib
 add_library(${PROJECT_NAME}

--- a/teapots/textured-teapot/src/main/cpp/CMakeLists.txt
+++ b/teapots/textured-teapot/src/main/cpp/CMakeLists.txt
@@ -29,11 +29,10 @@ if ((NOT EXISTS ${commonDir}/stb) OR
                     WORKING_DIRECTORY ${commonDir})
 endif()
 
-# build the ndk-helper library into a common directory
-# visible to all 3 projects avoiding duplicate builds.
-get_filename_component(ndkHelperSrc ${commonDir}/ndk_helper ABSOLUTE)
-get_filename_component(ndkHelperBin ${commonDir}/ndkHelperBin ABSOLUTE)
-add_subdirectory(${ndkHelperSrc} ${ndkHelperBin})
+# build the ndk-helper library
+get_filename_component(ndkHelperSrc ../../../../common/ndk_helper ABSOLUTE)
+add_subdirectory(${ndkHelperSrc}
+  ${CMAKE_BINARY_DIR}/ndkHelperBin)
 
 # now build app's shared lib
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
Among different projects that share on common module ( ndk_helper ), one project's build for ndk_helper actually not usable for other projects' dependency logic decision! In this project, it has 4 sub-project share one ndk_helper, if put it into the common binary into a dir NOT project dependent, every time building apks,  each APK activates one ndk_helper(so it got built 4 times every time ).

With the change, only the first time it will build 4 times, follow-up build will not re-build un-necessary ndk_helper module anymore.

the symptoms is same for desktop CMake projects: this change is necessary.
