### PR TITLE
NativeMedia sample: use application's assetManager

### DIFF
--- a/native-media/app/src/main/cpp/android_fopen.c
+++ b/native-media/app/src/main/cpp/android_fopen.c
@@ -37,7 +37,7 @@ static int android_close(void* cookie) {
 }
 
 // must be established by someone else...
-AAssetManager* android_asset_manager = NULL;
+static AAssetManager* android_asset_manager = NULL;
 void android_fopen_set_asset_manager(AAssetManager* manager) {
     android_asset_manager = manager;
 }

--- a/native-media/app/src/main/java/com/example/nativemedia/NativeMedia.java
+++ b/native-media/app/src/main/java/com/example/nativemedia/NativeMedia.java
@@ -68,7 +68,7 @@ public class NativeMedia extends Activity {
         setContentView(R.layout.main);
 
         // get application's assetManager to avoid being garbage-collected.
-        assetMgr = getAssets();
+        assetMgr = getApplication().getAssets();
 
         mGLView1 = (MyGLSurfaceView) findViewById(R.id.glsurfaceview1);
         mGLView2 = (MyGLSurfaceView) findViewById(R.id.glsurfaceview2);

--- a/native-media/app/src/main/java/com/example/nativemedia/NativeMedia.java
+++ b/native-media/app/src/main/java/com/example/nativemedia/NativeMedia.java
@@ -67,7 +67,8 @@ public class NativeMedia extends Activity {
         super.onCreate(icicle);
         setContentView(R.layout.main);
 
-        assetMgr = getResources().getAssets();
+        // get application's assetManager to avoid being garbage-collected.
+        assetMgr = getAssets();
 
         mGLView1 = (MyGLSurfaceView) findViewById(R.id.glsurfaceview1);
         mGLView2 = (MyGLSurfaceView) findViewById(R.id.glsurfaceview2);


### PR DESCRIPTION
This is to fix issue https://github.com/googlesamples/android-ndk/issues/571:
 should use application's assetManager, not Activity's assetManager to avoid being garbage collected
 