### PR TITLE
CI script update: no need to install with constraintLayout 1.0.2+

### DIFF
--- a/.ci_tools/setup_env.sh
+++ b/.ci_tools/setup_env.sh
@@ -30,6 +30,45 @@ retrieve_versions() {
     return 0
 }
 
+# helper function for src_str > target_str
+# Usage
+#     comp_ver_string src_str target_str
+# return:
+#   0: src_str <= target_str
+#   1: otherwise
+comp_ver_string () {
+#   $1: src_str, $2: target_str
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 0
+        fi
+
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+    done
+    return 0
+}
+
 ## Retrieve all necessary Android Platforms and install them all
 retrieve_versions compileSdkVersion $TMP_SETUP_FILENAME
 
@@ -45,8 +84,12 @@ done < $TMP_SETUP_FILENAME
 ## Retrieve constraint-layout versions
 retrieve_versions "constraint-layout:"  $TMP_SETUP_FILENAME
 while read -r version_; do
+  comp_ver_string $version_ "1.0.2"
+  if [[ $? -lt 1 ]]; then
+    # echo "installing constraintLayout $version_"
     $ANDROID_HOME/tools/bin/sdkmanager \
         "extras;m2repository;com;android;support;constraint;constraint-layout;$version_"
+  fi
 done < $TMP_SETUP_FILENAME
-#echo "constraint-layout versions:"; cat $TMP_SETUP_FILENAME;
+# echo "constraint-layout versions:"; cat $TMP_SETUP_FILENAME;
 rm -f $TMP_SETUP_FILENAME


### PR DESCRIPTION
inspired by: https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
Fact: constraintLayout 1.0.2+ could not be installed by sdkmanager, actually no need to install anymore. 