### PR TITLE
hello-oboe: add specific oboe-lib version to use

### DIFF
--- a/hello-oboe/app/src/main/cpp/CMakeLists.txt
+++ b/hello-oboe/app/src/main/cpp/CMakeLists.txt
@@ -16,6 +16,10 @@
 
 cmake_minimum_required(VERSION 3.4.1)
 
+# Pick up a stable Oboe lib version to use:
+# in the future, will point to a release branch rather than a commit hash
+set(OBOE_VERSION bb066c330a201913bd18686901381ad820c41296)
+
 ### INCLUDE OBOE LIBRARY ###
 get_filename_component(OBOE_SAMPLE_PROJ_HOME
         ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)
@@ -26,10 +30,10 @@ set(OBOE_SRC_DIR ${OBOE_SAMPLE_PROJ_HOME}/oboe)
 #     Android Studio's "Import Android code sample" option
 if ((NOT EXISTS ${OBOE_SRC_DIR}) OR
 (NOT EXISTS ${OBOE_SRC_DIR}/CMakeLists.txt))
-    execute_process(COMMAND git clone
-            https://github.com/google/oboe.git
-            oboe
+    execute_process(COMMAND git clone https://github.com/google/oboe.git oboe
             WORKING_DIRECTORY ${OBOE_SAMPLE_PROJ_HOME}/)
+    execute_process(COMMAND git checkout ${OBOE_VERSION}
+            WORKING_DIRECTORY ${OBOE_SAMPLE_PROJ_HOME}/oboe)
 endif()
 
 # Add the Oboe library as a subproject. Since Oboe is an out-of-tree source library we must also
@@ -52,5 +56,3 @@ target_link_libraries(hello-oboe android log oboe)
 # Enable optimization flags: if having problems with source level debugging,
 # disable -Ofast ( and debug ), re-enable after done debugging.
 target_compile_options(hello-oboe PRIVATE -Wall -Werror "$<$<CONFIG:RELEASE>:-Ofast>")
-
-


### PR DESCRIPTION
fix issue: https://github.com/googlesamples/android-ndk/issues/649
When oboe-stable branch 1.3.0 is released, will change to that one. For now fixing to the latest HASH as of TODAY.